### PR TITLE
Pull Request: Add Abbreviated Era Format and Improve First-Year Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,29 +31,29 @@ from jpdatetime import jpdatetime
 
 # Parsing Japanese era date string to a datetime object
 date_string = "令和5年10月30日"
-format_string = "%j年%m月%d日"
+format_string = "%G年%m月%d日"
 date_obj = jpdatetime.strptime(date_string, format_string)
 print(date_obj)  # Output: 2023-10-30 00:00:00
 
 # Formatting a datetime object to a Japanese era date string
 date = jpdatetime(2024, 10, 30)
-formatted_date = date.strftime("%j年%m月%d日")
+formatted_date = date.strftime("%G年%m月%d日")
 print(formatted_date)  # Output: "令和6年10月30日"
 
 # Handling the first year of an era
 date_string = "令和元年5月1日"
-format_string = "%j年%m月%d日"
+format_string = "%G年%m月%d日"
 date_obj = jpdatetime.strptime(date_string, format_string)
 print(date_obj)  # Output: 2019-05-01 00:00:00
 
 # Formatting a datetime object for the first year of an era
 date = jpdatetime(2019, 5, 1)
-formatted_date = date.strftime("%j年%m月%d日")
+formatted_date = date.strftime("%G年%m月%d日")
 print(formatted_date)  # Output: "令和元年5月1日"
 ```
 
 ### Format Specifiers
-- `%j`: Represents the Japanese era name and year. The format will be like "令和5" or "平成元" for the first year of the era.
+- `%G`: Represents the Japanese era name and year. The format will be like "令和5" or "平成元" for the first year of the era.
 - All other format specifiers (`%Y`, `%m`, `%d`, etc.) are identical to the standard `datetime` format specifiers.
 
 ## Limitation

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ print(formatted_date)  # Output: "令和元年5月1日"
 
 ### Format Specifiers
 - `%G`: Represents the Japanese era name and year. The format will be like "令和5" or "平成元" for the first year of the era.
+- `%g`: Represents the Japanese abbrivation era name and year. The format will be like "令2" or "平元" for the first year of the era.
 - All other format specifiers (`%Y`, `%m`, `%d`, etc.) are identical to the standard `datetime` format specifiers.
 
 ## Limitation

--- a/jpdatetime/jpdatetime.py
+++ b/jpdatetime/jpdatetime.py
@@ -17,7 +17,7 @@ class jpdatetime(datetime):
 
         Args:
             date_string (str): The date string in Japanese era format.
-            format_string (str): The format string, where %j is used to represent the era.
+            format_string (str): The format string, where %G is used to represent the era.
 
         Returns:
             jpdatetime: Parsed jpdatetime object.
@@ -27,7 +27,7 @@ class jpdatetime(datetime):
             start_year = cls._get_start_year(era_name)
             western_year = start_year + year_in_era - 1
             date_string = f"{western_year}年{date_string_wo_era}"
-            format_string = format_string.replace("%j", "%Y")
+            format_string = format_string.replace("%G", "%Y")
         return super().strptime(date_string, format_string)
 
     @classmethod
@@ -74,16 +74,16 @@ class jpdatetime(datetime):
         Format the date using a given format string, supporting Japanese era notation.
 
         Args:
-            format_string (str): The format string, where %j represents the Japanese era.
+            format_string (str): The format string, where %G represents the Japanese era.
 
         Returns:
             str: Formatted date string.
         """
-        if "%j" in format_string:
+        if "%G" in format_string:
             era, year_in_era = self._get_japanese_era()
             if era:
                 year_display = "元" if year_in_era == 1 else str(year_in_era)
-                format_string = format_string.replace("%j", f"{era}{year_display}")
+                format_string = format_string.replace("%G", f"{era}{year_display}")
         return super().strftime(format_string)
 
     def _get_japanese_era(self):

--- a/jpdatetime/jpdatetime.py
+++ b/jpdatetime/jpdatetime.py
@@ -88,12 +88,14 @@ class jpdatetime(datetime):
         if "%G" in format_string or "%g" in format_string:
             era, year_in_era = self._get_japanese_era()
             if era:
-                year_display = "元" if year_in_era == 1 else str(year_in_era)
+                year_display_G = "元" if year_in_era == 1 else str(year_in_era)
+                year_display_g = "1" if year_in_era == 1 else str(year_in_era)
                 short_era = self.ERA_MAP[era]["short"]
                 if "%G" in format_string:
-                    format_string = format_string.replace("%G", f"{era}{year_display}")
+                    format_string = format_string.replace("%G", f"{era}{year_display_G}")
                 if "%g" in format_string:
-                    format_string = format_string.replace("%g", f"{short_era}{year_display}")
+                    format_string = format_string.replace("%g", f"{short_era}{year_display_g}")
+        return super().strftime(format_string)
         return super().strftime(format_string)
 
     def _get_japanese_era(self):

--- a/test/test_jpdatetime.py
+++ b/test/test_jpdatetime.py
@@ -32,7 +32,7 @@ class Testjpdatetime(unittest.TestCase):
             (jpdatetime(2023, 10, 30), "%g年%m月%d日", "令5年10月30日"),
             (jpdatetime(2018, 4, 1), "%g年%m月%d日", "平30年04月01日"),
             (jpdatetime(1989, 1, 7), "%g年%m月%d日", "昭64年01月07日"),
-            (jpdatetime(1912, 7, 30), "%g年%m月%d日", "大元年07月30日"),
+            (jpdatetime(1912, 7, 30), "%g年%m月%d日", "大1年07月30日"),
             (jpdatetime(1912, 7, 29), "%g年%m月%d日", "明45年07月29日")
         ]
 

--- a/test/test_jpdatetime.py
+++ b/test/test_jpdatetime.py
@@ -13,7 +13,12 @@ class Testjpdatetime(unittest.TestCase):
             ("令和1年5月1日", "%G年%m月%d日", datetime(2019, 5, 1)),
             ("平成1年1月8日", "%G年%m月%d日", datetime(1989, 1, 8)),
             ("令和元年5月1日", "%G年%m月%d日", datetime(2019, 5, 1)),
-            ("平成元年1月8日", "%G年%m月%d日", datetime(1989, 1, 8))
+            ("平成元年1月8日", "%G年%m月%d日", datetime(1989, 1, 8)),
+            ("令5年10月30日", "%g年%m月%d日", datetime(2023, 10, 30)),
+            ("平30年4月1日", "%g年%m月%d日", datetime(2018, 4, 1)),
+            ("昭64年1月7日", "%g年%m月%d日", datetime(1989, 1, 7)),
+            ("大1年7月30日", "%g年%m月%d日", datetime(1912, 7, 30)),
+            ("明45年7月29日", "%g年%m月%d日", datetime(1912, 7, 29))
         ]
 
         self.test_cases_strftime = [
@@ -23,7 +28,12 @@ class Testjpdatetime(unittest.TestCase):
             (jpdatetime(1926, 12, 24), "%G年%m月%d日", "大正15年12月24日"),
             (jpdatetime(1912, 7, 29), "%G年%m月%d日", "明治45年07月29日"),
             (jpdatetime(2019, 5, 1), "%G年%m月%d日", "令和元年05月01日"),
-            (jpdatetime(1989, 1, 8), "%G年%m月%d日", "平成元年01月08日")
+            (jpdatetime(1989, 1, 8), "%G年%m月%d日", "平成元年01月08日"),
+            (jpdatetime(2023, 10, 30), "%g年%m月%d日", "令5年10月30日"),
+            (jpdatetime(2018, 4, 1), "%g年%m月%d日", "平30年04月01日"),
+            (jpdatetime(1989, 1, 7), "%g年%m月%d日", "昭64年01月07日"),
+            (jpdatetime(1912, 7, 30), "%g年%m月%d日", "大元年07月30日"),
+            (jpdatetime(1912, 7, 29), "%g年%m月%d日", "明45年07月29日")
         ]
 
     def test_strptime(self):

--- a/test/test_jpdatetime.py
+++ b/test/test_jpdatetime.py
@@ -5,25 +5,25 @@ from jpdatetime import jpdatetime
 class Testjpdatetime(unittest.TestCase):
     def setUp(self):
         self.test_cases_strptime = [
-            ("令和5年10月30日", "%j年%m月%d日", jpdatetime(2023, 10, 30)),
-            ("平成30年4月1日", "%j年%m月%d日", jpdatetime(2018, 4, 1)),
-            ("昭和64年1月7日", "%j年%m月%d日", jpdatetime(1989, 1, 7)),
-            ("大正15年12月24日", "%j年%m月%d日", jpdatetime(1926, 12, 24)),
-            ("明治45年7月29日", "%j年%m月%d日", jpdatetime(1912, 7, 29)),
-            ("令和1年5月1日", "%j年%m月%d日", jpdatetime(2019, 5, 1)),
-            ("平成1年1月8日", "%j年%m月%d日", jpdatetime(1989, 1, 8)),
-            ("令和元年5月1日", "%j年%m月%d日", jpdatetime(2019, 5, 1)),
-            ("平成元年1月8日", "%j年%m月%d日", jpdatetime(1989, 1, 8))
+            ("令和5年10月30日", "%G年%m月%d日", datetime(2023, 10, 30)),
+            ("平成30年4月1日", "%G年%m月%d日", datetime(2018, 4, 1)),
+            ("昭和64年1月7日", "%G年%m月%d日", datetime(1989, 1, 7)),
+            ("大正15年12月24日", "%G年%m月%d日", datetime(1926, 12, 24)),
+            ("明治45年7月29日", "%G年%m月%d日", datetime(1912, 7, 29)),
+            ("令和1年5月1日", "%G年%m月%d日", datetime(2019, 5, 1)),
+            ("平成1年1月8日", "%G年%m月%d日", datetime(1989, 1, 8)),
+            ("令和元年5月1日", "%G年%m月%d日", datetime(2019, 5, 1)),
+            ("平成元年1月8日", "%G年%m月%d日", datetime(1989, 1, 8))
         ]
 
         self.test_cases_strftime = [
-            (jpdatetime(2024, 10, 30), "%j年%m月%d日", "令和6年10月30日"),
-            (jpdatetime(2018, 4, 1), "%j年%m月%d日", "平成30年04月01日"),
-            (jpdatetime(1989, 1, 7), "%j年%m月%d日", "昭和64年01月07日"),
-            (jpdatetime(1926, 12, 24), "%j年%m月%d日", "大正15年12月24日"),
-            (jpdatetime(1912, 7, 29), "%j年%m月%d日", "明治45年07月29日"),
-            (jpdatetime(2019, 5, 1), "%j年%m月%d日", "令和元年05月01日"),
-            (jpdatetime(1989, 1, 8), "%j年%m月%d日", "平成元年01月08日")
+            (jpdatetime(2024, 10, 30), "%G年%m月%d日", "令和6年10月30日"),
+            (jpdatetime(2018, 4, 1), "%G年%m月%d日", "平成30年04月01日"),
+            (jpdatetime(1989, 1, 7), "%G年%m月%d日", "昭和64年01月07日"),
+            (jpdatetime(1926, 12, 24), "%G年%m月%d日", "大正15年12月24日"),
+            (jpdatetime(1912, 7, 29), "%G年%m月%d日", "明治45年07月29日"),
+            (jpdatetime(2019, 5, 1), "%G年%m月%d日", "令和元年05月01日"),
+            (jpdatetime(1989, 1, 8), "%G年%m月%d日", "平成元年01月08日")
         ]
 
     def test_strptime(self):


### PR DESCRIPTION
This pull request introduces several changes to the jpdatetime class to enhance its usability and flexibility for Japanese era formatting.

Key Changes:

Support for Abbreviated Era Names (%g): Added support for using abbreviated era names such as "令", "平", "昭" for compact date formatting. %g can be used in strftime to produce a more concise representation of Japanese dates.

Handling of First Year in %g Format: Modified the %g format to display "1" instead of "元" when formatting dates that are in the first year of an era. This makes %g more consistent with typical numeric year notations while %G retains traditional notation.

Refactored ERA_MAP: Combined full and abbreviated era information into a single dictionary (ERA_MAP) to simplify maintenance and improve code readability.

Benefits:

Enhanced Formatting Flexibility: Users can now choose between detailed (%G) and compact (%g) formats for displaying Japanese dates, which is especially useful for scenarios where space is limited.

Improved Code Maintainability: Refactoring ERA_MAP into a dictionary makes it easier to manage and extend the mappings for Japanese eras, reducing redundancy.

Testing:

Updated test cases to verify correct behavior of %g and %G formats, including the correct handling of the first year (displaying "1" for %g and "元" for %G).

Added additional unit tests for %g to cover abbreviated era formats for all supported eras.

Please review these changes and provide feedback. Any suggestions for further improvements are welcome.