### PR TITLE
8-change-format-string-j-to-g

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,13 @@ print(formatted_date)  # Output: "R1/05/01"
 | Directive | Meaning | Example |
 |-------------|-------------|-----------------|
 | `%G` | Full Japanese era name with year. Displays "令和元" for the first year and "平成30" for other years. | 令和元, 平成30 |
-| `%g` | Abbreviated Japanese era name (first character) with year. Shows "令1" for the first year and "平30" for other years. | 令01, 平30 |
+| `%-G`/`%#G` | Full Japanese era name with year (without zero-padding). Displays non-zero-padded numbers for other years (e.g., "平成6"). | 令和2, 平成6 |
+| `%g` | Abbreviated Japanese era name (first character) with year. Shows "令01" for the first year and zero-padded numbers for other years (e.g., "平30"). | 令01, 平30 |
+| `%-g`/`%#g` | Abbreviated Japanese era name with year (without zero-padding). Shows "令1" for the first year and non-zero-padded numbers for other years (e.g., "平30"). | 令1, 平6 |
 | `%E` | Full English era name with year. Displays "Reiwa 01" for the first year and "Heisei 30" for other years. | Reiwa 01, Heisei 30 |
+| `%-E`/`%#E` | Full English era name with year (without zero-padding). Displays "Reiwa 1" for the first year and non-zero-padded numbers for other years (e.g., "Heisei 30"). | Reiwa 1, Heisei 30 |
 | `%e` | Abbreviated English era name (first letter) with year. Shows "R01" for the first year and "H30" for other years. | R01, H30 |
+| `%-e`/`%#e` | Abbreviated English era name with year (without zero-padding). Shows "R1" for the first year and non-zero-padded numbers for other years (e.g., "H30"). | R1, H30 |
 
 `%Y`, `%m`, `%d`, `%B`, etc.: [Standard datetime format](https://docs.python.org/3/library/datetime.html#format-codes) specifiers.
 

--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ print(formatted_date)  # Output: "R1/05/01"
 | Directive | Meaning | Example |
 |-------------|-------------|-----------------|
 | `%G` | Full Japanese era name with year. Displays "令和元" for the first year and "平成30" for other years. | 令和元, 平成30 |
-| `%g` | Abbreviated Japanese era name (first character) with year. Shows "令1" for the first year and "平30" for other years. | 令1, 平30 |
-| `%E` | Full English era name with year. Displays "Reiwa 1" for the first year and "Heisei 30" for other years. | Reiwa 1, Heisei 30 |
-| `%e` | Abbreviated English era name (first letter) with year. Shows "R1" for the first year and "H30" for other years. | R1, H30 |
+| `%g` | Abbreviated Japanese era name (first character) with year. Shows "令1" for the first year and "平30" for other years. | 令01, 平30 |
+| `%E` | Full English era name with year. Displays "Reiwa 01" for the first year and "Heisei 30" for other years. | Reiwa 01, Heisei 30 |
+| `%e` | Abbreviated English era name (first letter) with year. Shows "R01" for the first year and "H30" for other years. | R01, H30 |
 
 `%Y`, `%m`, `%d`, `%B`, etc.: [Standard datetime format](https://docs.python.org/3/library/datetime.html#format-codes) specifiers.
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 [![Test](https://github.com/new-village/cnparser/actions/workflows/test.yaml/badge.svg)](https://github.com/new-village/cnparser/actions/workflows/test.yaml)
 ![PyPI - Version](https://img.shields.io/pypi/v/jpdatetime)
 
-The jpdatetime library extends Python's datetime to support Japanese eras (元号). It allows parsing and formatting dates in Japanese eras like Reiwa (令和), Heisei (平成), and more, including special support for first-year notation (元年).
+The `jpdatetime` library extends Python's `datetime` to support Japanese eras (元号). It allows parsing and formatting dates using Japanese era names like Reiwa (令和), Heisei (平成), and more, including special support for first-year notation (元年).
 
 ## Features
-* Convert Japanese era dates to Gregorian dates using the `strptime` method.
-* Convert Gregorian dates to Japanese era formatted strings using the `strftime` method.
-* Supports the Japanese eras: Meiji, Taisho, Showa, Heisei, and Reiwa.
-* Supports the first year notation (元年) for each era.
-* Allows custom formatting that includes both Japanese and Gregorian dates.
+- **Parsing**: Convert Japanese era date strings to Gregorian dates using the `strptime` method.
+- **Formatting**: Convert Gregorian dates to Japanese era formatted strings using the `strftime` method.
+- **Supported Eras**: Meiji (明治), Taisho (大正), Showa (昭和), Heisei (平成), and Reiwa (令和).
+- **First Year Notation**: Supports the first-year notation (元年) for each era.
+- **Custom Formatting**: Allows custom formatting that includes both Japanese and Gregorian dates.
 
 ## Installation
 `jpdatetime` is available for installation via pip.
@@ -50,17 +50,54 @@ print(date_obj)  # Output: 2019-05-01 00:00:00
 date = jpdatetime(2019, 5, 1)
 formatted_date = date.strftime("%G年%m月%d日")
 print(formatted_date)  # Output: "令和元年5月1日"
+
+# Using abbreviated era names
+date_string = "令1年10月30日"
+format_string = "%g年%m月%d日"
+date_obj = jpdatetime.strptime(date_string, format_string)
+print(date_obj)  # Output: 2019-10-30 00:00:00
+
+date = jpdatetime(2019, 10, 30)
+formatted_date = date.strftime("%g年%m月%d日")
+print(formatted_date)  # Output: "令1年10月30日"
+
+# Using English era names
+date_string = "Heisei 30, April 1"
+format_string = "%E, %B %d"
+date_obj = jpdatetime.strptime(date_string, format_string)
+print(date_obj)  # Output: 2018-04-01 00:00:00
+
+date = jpdatetime(2018, 4, 1)
+formatted_date = date.strftime("%E, %B %d")
+print(formatted_date)  # Output: "Heisei 30, April 01"
+
+# Using abbreviated English era names
+date_string = "R1/05/01"
+format_string = "%e/%m/%d"
+date_obj = jpdatetime.strptime(date_string, format_string)
+print(date_obj)  # Output: 2019-05-01 00:00:00
+
+date = jpdatetime(2019, 5, 1)
+formatted_date = date.strftime("%e/%m/%d")
+print(formatted_date)  # Output: "R1/05/01"
 ```
 
-### Format Specifiers
-- `%G`: Represents the Japanese era name and year. The format will be like "令和5" or "平成元" for the first year of the era.
-- `%g`: Represents the Japanese abbrivation era name and year. The format will be like "令2" or "平元" for the first year of the era.
-- All other format specifiers (`%Y`, `%m`, `%d`, etc.) are identical to the standard `datetime` format specifiers.
+### `strftime()` and `strptime()` Format Codes 
+
+| Directive | Meaning | Example |
+|-------------|-------------|-----------------|
+| `%G` | Full Japanese era name with year. Displays "令和元" for the first year and "平成30" for other years. | 令和元, 平成30 |
+| `%g` | Abbreviated Japanese era name (first character) with year. Shows "令1" for the first year and "平30" for other years. | 令1, 平30 |
+| `%E` | Full English era name with year. Displays "Reiwa 1" for the first year and "Heisei 30" for other years. | Reiwa 1, Heisei 30 |
+| `%e` | Abbreviated English era name (first letter) with year. Shows "R1" for the first year and "H30" for other years. | R1, H30 |
+
+`%Y`, `%m`, `%d`, `%B`, etc.: [Standard datetime format](https://docs.python.org/3/library/datetime.html#format-codes) specifiers.
 
 ## Limitation
-- This library does not support Japanese eras prior to Meiji (i.e., before Meiji元年, which started on September 8, 1868).
-- Date parsing and formatting are limited to the supported eras (Meiji, Taisho, Showa, Heisei, and Reiwa).
-- The library does not account for dates outside of these eras or hypothetical future eras not explicitly defined.
+- **Supported Eras**: The library supports Meiji (from September 8, 1868) onwards. Eras prior to Meiji are not supported.
+- **Date Range**: Parsing and formatting are limited to the supported eras (Meiji, Taisho, Showa, Heisei, and Reiwa).
+- **Future Eras**: The library does not account for hypothetical future eras not explicitly defined in the eras list.
+- **Locale Considerations**: Month names and other locale-specific strings are in English. Localization for other languages is not provided.
 
 ## Contributing
 

--- a/jpdatetime/eras.json
+++ b/jpdatetime/eras.json
@@ -1,0 +1,7 @@
+[
+    {"name_en": "Reiwa", "name_ja": "令和", "start_date": "2019-05-01"},
+    {"name_en": "Heisei", "name_ja": "平成", "start_date": "1989-01-08"},
+    {"name_en": "Showa", "name_ja": "昭和", "start_date": "1926-12-25"},
+    {"name_en": "Taisho", "name_ja": "大正", "start_date": "1912-07-30"},
+    {"name_en": "Meiji", "name_ja": "明治", "start_date": "1868-09-08"}
+]

--- a/jpdatetime/jpdatetime.py
+++ b/jpdatetime/jpdatetime.py
@@ -187,7 +187,10 @@ class jpdatetime(datetime):
         """Formats the date using full Japanese era name."""
         era = self._get_era_info()
         era_year = self.year - era['start_date'].year + 1
-        era_year_str = '元' if era_year == 1 else str(era_year)
+        if era_year == 1:
+            era_year_str = '元'
+        else:
+            era_year_str = f"{era_year:02d}"  # Zero-pad to two digits
         return f"{era['name_ja']}{era_year_str}"
 
     def _format_abbr_jp_era(self):
@@ -195,14 +198,14 @@ class jpdatetime(datetime):
         era = self._get_era_info()
         era_year = self.year - era['start_date'].year + 1
         era_abbr = era['name_ja'][0]
-        era_year_str = str(era_year)
+        era_year_str = f"{era_year:02d}"  # Zero-pad to two digits
         return f"{era_abbr}{era_year_str}"
 
     def _format_full_en_era(self):
         """Formats the date using full English era name."""
         era = self._get_era_info()
         era_year = self.year - era['start_date'].year + 1
-        era_year_str = str(era_year)
+        era_year_str = f"{era_year:02d}"  # Zero-pad to two digits
         return f"{era['name_en']} {era_year_str}"
 
     def _format_abbr_en_era(self):
@@ -210,5 +213,5 @@ class jpdatetime(datetime):
         era = self._get_era_info()
         era_year = self.year - era['start_date'].year + 1
         era_abbr = era['name_en'][0]
-        era_year_str = str(era_year)
+        era_year_str = f"{era_year:02d}"  # Zero-pad to two digits
         return f"{era_abbr}{era_year_str}"

--- a/jpdatetime/jpdatetime.py
+++ b/jpdatetime/jpdatetime.py
@@ -1,14 +1,20 @@
+import os
 import re
+import json
 from datetime import datetime
 
-# List of Japanese eras with their names and starting dates
-eras = [
-    {'name_en': 'Reiwa', 'name_ja': '令和', 'start_date': datetime(2019, 5, 1)},
-    {'name_en': 'Heisei', 'name_ja': '平成', 'start_date': datetime(1989, 1, 8)},
-    {'name_en': 'Showa', 'name_ja': '昭和', 'start_date': datetime(1926, 12, 25)},
-    {'name_en': 'Taisho', 'name_ja': '大正', 'start_date': datetime(1912, 7, 30)},
-    {'name_en': 'Meiji', 'name_ja': '明治', 'start_date': datetime(1868, 9, 8)},
-]
+# Load the eras data from an external JSON file
+module_dir = os.path.dirname(os.path.abspath(__file__))
+eras_file_path = os.path.join(module_dir, 'eras.json')
+
+with open(eras_file_path, 'r', encoding='utf-8') as f:
+    eras_data = json.load(f)
+
+# Parse the start dates into datetime objects
+eras = []
+for era in eras_data:
+    era['start_date'] = datetime.strptime(era['start_date'], '%Y-%m-%d')
+    eras.append(era)
 
 class jpdatetime(datetime):
     # Unified custom format codes mapping to their handler functions

--- a/jpdatetime/jpdatetime.py
+++ b/jpdatetime/jpdatetime.py
@@ -1,113 +1,214 @@
+import re
 from datetime import datetime
 
+# List of Japanese eras with their names and starting dates
+eras = [
+    {'name_en': 'Reiwa', 'name_ja': '令和', 'start_date': datetime(2019, 5, 1)},
+    {'name_en': 'Heisei', 'name_ja': '平成', 'start_date': datetime(1989, 1, 8)},
+    {'name_en': 'Showa', 'name_ja': '昭和', 'start_date': datetime(1926, 12, 25)},
+    {'name_en': 'Taisho', 'name_ja': '大正', 'start_date': datetime(1912, 7, 30)},
+    {'name_en': 'Meiji', 'name_ja': '明治', 'start_date': datetime(1868, 9, 8)},
+]
+
 class jpdatetime(datetime):
-    # Mapping of Japanese eras to their starting dates and short names
-    ERA_MAP = {
-        "令和": {"short": "令", "start_date": datetime(2019, 5, 1)},
-        "平成": {"short": "平", "start_date": datetime(1989, 1, 8)},
-        "昭和": {"short": "昭", "start_date": datetime(1926, 12, 25)},
-        "大正": {"short": "大", "start_date": datetime(1912, 7, 30)},
-        "明治": {"short": "明", "start_date": datetime(1868, 9, 8)}
+    # Unified custom format codes mapping to their handler functions
+    custom_formats = {
+        '%G': {'parse': 'parse_full_jp_era', 'format': 'format_full_jp_era'},
+        '%g': {'parse': 'parse_abbr_jp_era', 'format': 'format_abbr_jp_era'},
+        '%E': {'parse': 'parse_full_en_era', 'format': 'format_full_en_era'},
+        '%e': {'parse': 'parse_abbr_en_era', 'format': 'format_abbr_en_era'},
     }
 
     @classmethod
     def strptime(cls, date_string, format_string):
-        """
-        Parse a string representing a date in Japanese era format to a jpdatetime object.
+        # Check if custom era format codes are in the format string
+        if any(code in format_string for code in cls.custom_formats):
+            # Split the format string into tokens
+            tokens = cls._tokenize_format_string(format_string)
+            regex_pattern = ''
+            for token_type, token_value in tokens:
+                if token_type == 'format_code':
+                    if token_value in cls.custom_formats:
+                        # Get the regex pattern for the custom format code
+                        handler_name = cls.custom_formats[token_value]['parse']
+                        handler = getattr(cls, f"_get_regex_{handler_name}")
+                        regex_pattern += handler()
+                    else:
+                        # Use the standard datetime regex patterns
+                        regex_pattern += cls._escape_regex(token_value)
+                else:
+                    # Escape literals in the regex pattern
+                    regex_pattern += re.escape(token_value)
 
-        Args:
-            date_string (str): The date string in Japanese era format.
-            format_string (str): The format string, where %G is used to represent the era.
+            # Compile the regex pattern
+            match = re.match(regex_pattern, date_string)
+            if not match:
+                raise ValueError(f"time data '{date_string}' does not match format '{format_string}'")
 
-        Returns:
-            jpdatetime: Parsed jpdatetime object.
-        """
-        era_name, year_in_era, date_string_wo_era = cls._extract_era_info(date_string)
-        if era_name:
-            start_year = cls._get_start_year(era_name)
-            western_year = start_year + year_in_era - 1
-            date_string = f"{western_year}年{date_string_wo_era}"
-            format_string = format_string.replace("%G", "%Y").replace("%g", "%Y")
-        return super().strptime(date_string, format_string)
-
-    @classmethod
-    def _extract_era_info(cls, date_string):
-        """
-        Extract the era name and year from the date string.
-
-        Args:
-            date_string (str): The date string in Japanese era format.
-
-        Returns:
-            tuple: A tuple containing the era name, year in the era, and remaining date string.
-        """
-        for era_name, era_info in cls.ERA_MAP.items():
-            short_name = era_info["short"]
-            if era_name in date_string:
-                date_string_wo_era = date_string.replace(era_name, "").strip()
-                year_part = date_string_wo_era.split("年")[0].strip()
-                year_in_era = 1 if year_part == "元" else int(year_part)
-                date_string_wo_era = date_string_wo_era.split("年", 1)[1]
-                return era_name, year_in_era, date_string_wo_era
-            elif short_name in date_string:
-                date_string_wo_era = date_string.replace(short_name, "").strip()
-                year_part = date_string_wo_era.split("年")[0].strip()
-                year_in_era = 1 if year_part == "元" else int(year_part)
-                date_string_wo_era = date_string_wo_era.split("年", 1)[1]
-                return era_name, year_in_era, date_string_wo_era
-        return None, None, None
-
-    @classmethod
-    def _get_start_year(cls, era_name):
-        """
-        Get the starting year of the specified era.
-
-        Args:
-            era_name (str): The name of the Japanese era.
-
-        Returns:
-            int: The starting year of the era.
-
-        Raises:
-            ValueError: If the era name is unknown.
-        """
-        if era_name in cls.ERA_MAP:
-            return cls.ERA_MAP[era_name]["start_date"].year
-        raise ValueError(f"Unknown era: {era_name}")
+            # Extract date components from matched groups
+            components = match.groupdict()
+            year, month, day = cls._extract_date_components(components)
+            return cls(year, month, day)
+        else:
+            # Use standard datetime parsing for formats without custom codes
+            dt = datetime.strptime(date_string, format_string)
+            return cls(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second, dt.microsecond)
 
     def strftime(self, format_string):
-        """
-        Format the date using a given format string, supporting Japanese era notation.
+        # Check if custom era format codes are in the format string
+        if any(code in format_string for code in self.custom_formats):
+            tokens = self._tokenize_format_string(format_string)
+            result = ''
+            for token_type, token_value in tokens:
+                if token_type == 'format_code':
+                    if token_value in self.custom_formats:
+                        # Call the handler function for the custom format code
+                        handler_name = self.custom_formats[token_value]['format']
+                        handler = getattr(self, f"_{handler_name}")
+                        result += handler()
+                    else:
+                        # Use standard datetime strftime for other format codes
+                        result += super().strftime(token_value)
+                else:
+                    # Append literals as is
+                    result += token_value
+            return result
+        else:
+            # Use standard datetime strftime for formats without custom codes
+            return super().strftime(format_string)
 
-        Args:
-            format_string (str): The format string, where %G represents the Japanese era.
+    @classmethod
+    def _tokenize_format_string(cls, format_string):
+        """Tokenizes the format string into format codes and literals."""
+        tokens = []
+        pattern = re.compile(r'(%.)')
+        parts = pattern.split(format_string)
+        for part in parts:
+            if part.startswith('%') and len(part) > 1:
+                tokens.append(('format_code', part))
+            else:
+                tokens.append(('literal', part))
+        return tokens
 
-        Returns:
-            str: Formatted date string.
-        """
-        if "%G" in format_string or "%g" in format_string:
-            era, year_in_era = self._get_japanese_era()
-            if era:
-                year_display_G = "元" if year_in_era == 1 else str(year_in_era)
-                year_display_g = "1" if year_in_era == 1 else str(year_in_era)
-                short_era = self.ERA_MAP[era]["short"]
-                if "%G" in format_string:
-                    format_string = format_string.replace("%G", f"{era}{year_display_G}")
-                if "%g" in format_string:
-                    format_string = format_string.replace("%g", f"{short_era}{year_display_g}")
-        return super().strftime(format_string)
-        return super().strftime(format_string)
+    @staticmethod
+    def _escape_regex(format_code):
+        """Escapes standard format codes for regex."""
+        regex_patterns = {
+            '%Y': r'(?P<year>\d{4})',
+            '%m': r'(?P<month>\d{1,2})',
+            '%d': r'(?P<day>\d{1,2})',
+            '%B': r'(?P<month_name>[A-Za-z]+)',
+            # Add other standard patterns as needed
+        }
+        return regex_patterns.get(format_code, re.escape(format_code))
 
-    def _get_japanese_era(self):
-        """
-        Determine the Japanese era and the year within that era for the current date.
+    @classmethod
+    def _get_regex_parse_full_jp_era(cls):
+        """Returns the regex pattern for full Japanese era names."""
+        era_names = '|'.join([era['name_ja'] for era in eras])
+        return rf'(?P<era_full_jp>{era_names})(?P<era_year>元|\d+)'
 
-        Returns:
-            tuple: A tuple containing the era name and the year within the era.
-        """
-        for era, era_info in jpdatetime.ERA_MAP.items():
-            start_date = era_info["start_date"]
-            if self >= start_date:
-                year_in_era = self.year - start_date.year + 1
-                return era, year_in_era
-        return "", self.year
+    @classmethod
+    def _get_regex_parse_abbr_jp_era(cls):
+        """Returns the regex pattern for abbreviated Japanese era names."""
+        era_abbrs = ''.join([era['name_ja'][0] for era in eras])
+        return rf'(?P<era_abbr_jp>[{era_abbrs}])(?P<era_year>元|\d+)'
+
+    @classmethod
+    def _get_regex_parse_full_en_era(cls):
+        """Returns the regex pattern for full English era names."""
+        era_names = '|'.join([era['name_en'] for era in eras])
+        return rf'(?P<era_full_en>{era_names}) (?P<era_year>First|\d+)'
+
+    @classmethod
+    def _get_regex_parse_abbr_en_era(cls):
+        """Returns the regex pattern for abbreviated English era names."""
+        era_abbrs = ''.join([era['name_en'][0] for era in eras])
+        return rf'(?P<era_abbr_en>[{era_abbrs}])(?P<era_year>First|\d+)'
+
+    @classmethod
+    def _extract_date_components(cls, components):
+        """Extracts and calculates the date components from regex match groups."""
+        # Initialize default values
+        year = month = day = None
+
+        # Handle era information
+        era = None
+        era_year_str = components.get('era_year')
+        if 'era_full_jp' in components and components['era_full_jp']:
+            era_name = components['era_full_jp']
+            era = next((e for e in eras if e['name_ja'] == era_name), None)
+        elif 'era_abbr_jp' in components and components['era_abbr_jp']:
+            era_abbr = components['era_abbr_jp']
+            era = next((e for e in eras if e['name_ja'][0] == era_abbr), None)
+        elif 'era_full_en' in components and components['era_full_en']:
+            era_name = components['era_full_en']
+            era = next((e for e in eras if e['name_en'] == era_name), None)
+        elif 'era_abbr_en' in components and components['era_abbr_en']:
+            era_abbr = components['era_abbr_en']
+            era = next((e for e in eras if e['name_en'][0] == era_abbr), None)
+
+        # Determine the era year
+        if era and era_year_str:
+            if era_year_str in ('元', 'First'):
+                era_year = 1
+            else:
+                era_year = int(era_year_str)
+            year = era['start_date'].year + era_year - 1
+
+        # Handle standard year if era is not used
+        if not year and 'year' in components:
+            year = int(components['year'])
+
+        # Handle month
+        if 'month' in components and components['month']:
+            month = int(components['month'])
+        elif 'month_name' in components and components['month_name']:
+            month_name = components['month_name']
+            month = datetime.strptime(month_name, '%B').month
+
+        # Handle day
+        if 'day' in components and components['day']:
+            day = int(components['day'])
+
+        if None in (year, month, day):
+            raise ValueError("Incomplete date information")
+
+        return year, month, day
+
+    def _get_era_info(self):
+        """Retrieves the era information for the current date."""
+        for era in eras:
+            if self >= era['start_date']:
+                return era
+        raise ValueError("Date out of range for Japanese eras")
+
+    def _format_full_jp_era(self):
+        """Formats the date using full Japanese era name."""
+        era = self._get_era_info()
+        era_year = self.year - era['start_date'].year + 1
+        era_year_str = '元' if era_year == 1 else str(era_year)
+        return f"{era['name_ja']}{era_year_str}"
+
+    def _format_abbr_jp_era(self):
+        """Formats the date using abbreviated Japanese era name."""
+        era = self._get_era_info()
+        era_year = self.year - era['start_date'].year + 1
+        era_abbr = era['name_ja'][0]
+        era_year_str = str(era_year)
+        return f"{era_abbr}{era_year_str}"
+
+    def _format_full_en_era(self):
+        """Formats the date using full English era name."""
+        era = self._get_era_info()
+        era_year = self.year - era['start_date'].year + 1
+        era_year_str = str(era_year)
+        return f"{era['name_en']} {era_year_str}"
+
+    def _format_abbr_en_era(self):
+        """Formats the date using abbreviated English era name."""
+        era = self._get_era_info()
+        era_year = self.year - era['start_date'].year + 1
+        era_abbr = era['name_en'][0]
+        era_year_str = str(era_year)
+        return f"{era_abbr}{era_year_str}"

--- a/test/test_jpdatetime.py
+++ b/test/test_jpdatetime.py
@@ -4,204 +4,282 @@ from jpdatetime import jpdatetime
 
 class Testjpdatetime(unittest.TestCase):
     def setUp(self):
-        # Test cases for %G format (Full Japanese Era Name)
-        self.test_cases_strptime_G = [
-            # Existing test cases
-            ("令和5年10月30日", "%G年%m月%d日", datetime(2023, 10, 30)),
-            ("平成30年4月1日", "%G年%m月%d日", datetime(2018, 4, 1)),
-            ("昭和64年1月7日", "%G年%m月%d日", datetime(1989, 1, 7)),
-            ("大正15年12月24日", "%G年%m月%d日", datetime(1926, 12, 24)),
-            ("明治45年7月29日", "%G年%m月%d日", datetime(1912, 7, 29)),
-            ("令和元年5月1日", "%G年%m月%d日", datetime(2019, 5, 1)),
-            ("平成元年1月8日", "%G年%m月%d日", datetime(1989, 1, 8)),
-            # Additional test cases
-            ("令和6年1月1日", "%G年%m月%d日", datetime(2024, 1, 1)),
-            ("平成元年12月31日", "%G年%m月%d日", datetime(1989, 12, 31)),
-            ("昭和元年12月25日", "%G年%m月%d日", datetime(1926, 12, 25)),
-            ("大正元年7月30日", "%G年%m月%d日", datetime(1912, 7, 30)),
-            ("明治元年9月8日", "%G年%m月%d日", datetime(1868, 9, 8)),
-            # Edge case: Date just before an era change
-            ("平成31年4月30日", "%G年%m月%d日", datetime(2019, 4, 30)),
-            # Leap year
-            ("平成4年2月29日", "%G年%m月%d日", datetime(1992, 2, 29)),
-        ]
-
-        # Test cases for %g format (Abbreviated Japanese Era Name)
-        self.test_cases_strptime_g = [
-            # Existing test cases
-            ("令5年10月30日", "%g年%m月%d日", datetime(2023, 10, 30)),
-            ("平30年4月1日", "%g年%m月%d日", datetime(2018, 4, 1)),
-            ("昭64年1月7日", "%g年%m月%d日", datetime(1989, 1, 7)),
-            ("大1年7月30日", "%g年%m月%d日", datetime(1912, 7, 30)),
-            ("明45年7月29日", "%g年%m月%d日", datetime(1912, 7, 29)),
-            # Additional test cases
-            ("令1年5月1日", "%g年%m月%d日", datetime(2019, 5, 1)),
-            ("平1年1月8日", "%g年%m月%d日", datetime(1989, 1, 8)),
-            ("昭1年12月25日", "%g年%m月%d日", datetime(1926, 12, 25)),
-            ("大元年7月30日", "%g年%m月%d日", datetime(1912, 7, 30)),
-            ("明元年9月8日", "%g年%m月%d日", datetime(1868, 9, 8)),
-            # Edge case: Date just before an era change
-            ("平31年4月30日", "%g年%m月%d日", datetime(2019, 4, 30)),
-            # Leap year
-            ("平4年2月29日", "%g年%m月%d日", datetime(1992, 2, 29)),
-        ]
-
-        # Test cases for %E format (Full English Era Name)
-        self.test_cases_strptime_E = [
-            # Existing test cases
-            ("Reiwa 5, October 30", "%E, %B %d", datetime(2023, 10, 30)),
-            ("Heisei 30, April 1", "%E, %B %d", datetime(2018, 4, 1)),
-            ("Showa 64, January 7", "%E, %B %d", datetime(1989, 1, 7)),
-            ("Taisho 15, December 24", "%E, %B %d", datetime(1926, 12, 24)),
-            ("Meiji 45, July 29", "%E, %B %d", datetime(1912, 7, 29)),
-            # Additional test cases
-            ("Reiwa 1, May 1", "%E, %B %d", datetime(2019, 5, 1)),
-            ("Heisei 1, January 8", "%E, %B %d", datetime(1989, 1, 8)),
-            ("Showa 1, December 25", "%E, %B %d", datetime(1926, 12, 25)),
-            ("Taisho 1, July 30", "%E, %B %d", datetime(1912, 7, 30)),
-            ("Meiji 1, September 8", "%E, %B %d", datetime(1868, 9, 8)),
-            # Edge case: Date just before an era change
-            ("Heisei 31, April 30", "%E, %B %d", datetime(2019, 4, 30)),
-            # Leap year
-            ("Heisei 4, February 29", "%E, %B %d", datetime(1992, 2, 29)),
-        ]
-
-        # Test cases for %e format (Abbreviated English Era Name)
-        self.test_cases_strptime_e = [
-            # Existing test cases
-            ("R5/10/30", "%e/%m/%d", datetime(2023, 10, 30)),
-            ("H30/4/1", "%e/%m/%d", datetime(2018, 4, 1)),
-            ("S64/1/7", "%e/%m/%d", datetime(1989, 1, 7)),
-            ("T15/12/24", "%e/%m/%d", datetime(1926, 12, 24)),
-            ("M45/7/29", "%e/%m/%d", datetime(1912, 7, 29)),
-            # Additional test cases
-            ("R1/5/1", "%e/%m/%d", datetime(2019, 5, 1)),
-            ("H1/1/8", "%e/%m/%d", datetime(1989, 1, 8)),
-            ("S1/12/25", "%e/%m/%d", datetime(1926, 12, 25)),
-            ("T1/7/30", "%e/%m/%d", datetime(1912, 7, 30)),
-            ("M1/9/8", "%e/%m/%d", datetime(1868, 9, 8)),
-            # Edge case: Date just before an era change
-            ("H31/4/30", "%e/%m/%d", datetime(2019, 4, 30)),
-            # Leap year
-            ("H4/02/29", "%e/%m/%d", datetime(1992, 2, 29)),
-        ]
-
-        # Separate test cases for strftime (%G)
+        # Test cases for strftime with %G format (Full Japanese Era Name)
         self.test_cases_strftime_G = [
-            # Existing test cases with zero-padded years
-            (jpdatetime(2024, 10, 30), "%G年%m月%d日", "令和06年10月30日"),
-            (jpdatetime(2018, 4, 1), "%G年%m月%d日", "平成30年04月01日"),
-            (jpdatetime(1989, 1, 7), "%G年%m月%d日", "昭和64年01月07日"),
-            (jpdatetime(1926, 12, 24), "%G年%m月%d日", "大正15年12月24日"),
-            (jpdatetime(1912, 7, 29), "%G年%m月%d日", "明治45年07月29日"),
+            # Reiwa Era
+            (jpdatetime(2023, 10, 30), "%G年%m月%d日", "令和05年10月30日"),
+            (jpdatetime(2023, 10, 30), "%-G年%m月%d日", "令和5年10月30日"),
             (jpdatetime(2019, 5, 1), "%G年%m月%d日", "令和元年05月01日"),
+            (jpdatetime(2019, 5, 1), "%-G年%m月%d日", "令和元年05月01日"),
+            # Heisei Era
+            (jpdatetime(2018, 4, 1), "%G年%m月%d日", "平成30年04月01日"),
+            (jpdatetime(2018, 4, 1), "%-G年%m月%d日", "平成30年04月01日"),
             (jpdatetime(1989, 1, 8), "%G年%m月%d日", "平成元年01月08日"),
-            # Additional test cases with zero-padded years
+            (jpdatetime(1989, 1, 8), "%-G年%m月%d日", "平成元年01月08日"),
+            # Showa Era
+            (jpdatetime(1989, 1, 7), "%G年%m月%d日", "昭和64年01月07日"),
+            (jpdatetime(1989, 1, 7), "%-G年%m月%d日", "昭和64年01月07日"),
             (jpdatetime(1926, 12, 25), "%G年%m月%d日", "昭和元年12月25日"),
+            (jpdatetime(1926, 12, 25), "%-G年%m月%d日", "昭和元年12月25日"),
+            # Taisho Era
+            (jpdatetime(1926, 12, 24), "%G年%m月%d日", "大正15年12月24日"),
+            (jpdatetime(1926, 12, 24), "%-G年%m月%d日", "大正15年12月24日"),
             (jpdatetime(1912, 7, 30), "%G年%m月%d日", "大正元年07月30日"),
+            (jpdatetime(1912, 7, 30), "%-G年%m月%d日", "大正元年07月30日"),
+            # Meiji Era
+            (jpdatetime(1912, 7, 29), "%G年%m月%d日", "明治45年07月29日"),
+            (jpdatetime(1912, 7, 29), "%-G年%m月%d日", "明治45年07月29日"),
             (jpdatetime(1868, 9, 8), "%G年%m月%d日", "明治元年09月08日"),
-            # Edge case: Date just before an era change
-            (jpdatetime(2019, 4, 30), "%G年%m月%d日", "平成31年04月30日"),
-            # Leap year
-            (jpdatetime(1992, 2, 29), "%G年%m月%d日", "平成04年02月29日"),
+            (jpdatetime(1868, 9, 8), "%-G年%m月%d日", "明治元年09月08日"),
         ]
 
-        # Separate test cases for strftime (%g)
+        # Test cases for strftime with %g format (Abbreviated Japanese Era Name)
         self.test_cases_strftime_g = [
-            # Existing test cases with zero-padded years
+            # Reiwa Era
             (jpdatetime(2023, 10, 30), "%g年%m月%d日", "令05年10月30日"),
-            (jpdatetime(2018, 4, 1), "%g年%m月%d日", "平30年04月01日"),
-            (jpdatetime(1989, 1, 7), "%g年%m月%d日", "昭64年01月07日"),
-            (jpdatetime(1912, 7, 30), "%g年%m月%d日", "大01年07月30日"),
-            (jpdatetime(1912, 7, 29), "%g年%m月%d日", "明45年07月29日"),
-            # Additional test cases with zero-padded years
+            (jpdatetime(2023, 10, 30), "%-g年%m月%d日", "令5年10月30日"),
             (jpdatetime(2019, 5, 1), "%g年%m月%d日", "令01年05月01日"),
+            (jpdatetime(2019, 5, 1), "%-g年%m月%d日", "令1年05月01日"),
+            # Heisei Era
+            (jpdatetime(2018, 4, 1), "%g年%m月%d日", "平30年04月01日"),
+            (jpdatetime(2018, 4, 1), "%-g年%m月%d日", "平30年04月01日"),
             (jpdatetime(1989, 1, 8), "%g年%m月%d日", "平01年01月08日"),
+            (jpdatetime(1989, 1, 8), "%-g年%m月%d日", "平1年01月08日"),
+            # Showa Era
+            (jpdatetime(1989, 1, 7), "%g年%m月%d日", "昭64年01月07日"),
+            (jpdatetime(1989, 1, 7), "%-g年%m月%d日", "昭64年01月07日"),
             (jpdatetime(1926, 12, 25), "%g年%m月%d日", "昭01年12月25日"),
+            (jpdatetime(1926, 12, 25), "%-g年%m月%d日", "昭1年12月25日"),
+            # Taisho Era
+            (jpdatetime(1926, 12, 24), "%g年%m月%d日", "大15年12月24日"),
+            (jpdatetime(1926, 12, 24), "%-g年%m月%d日", "大15年12月24日"),
+            (jpdatetime(1912, 7, 30), "%g年%m月%d日", "大01年07月30日"),
+            (jpdatetime(1912, 7, 30), "%-g年%m月%d日", "大1年07月30日"),
+            # Meiji Era
+            (jpdatetime(1912, 7, 29), "%g年%m月%d日", "明45年07月29日"),
+            (jpdatetime(1912, 7, 29), "%-g年%m月%d日", "明45年07月29日"),
             (jpdatetime(1868, 9, 8), "%g年%m月%d日", "明01年09月08日"),
-            # Edge case: Date just before an era change
-            (jpdatetime(2019, 4, 30), "%g年%m月%d日", "平31年04月30日"),
-            # Leap year
-            (jpdatetime(1992, 2, 29), "%g年%m月%d日", "平04年02月29日"),
+            (jpdatetime(1868, 9, 8), "%-g年%m月%d日", "明1年09月08日"),
         ]
 
-        # Separate test cases for strftime (%E)
+        # Test cases for strftime with %E format (Full English Era Name)
         self.test_cases_strftime_E = [
-            # Existing test cases with zero-padded years
+            # Reiwa Era
             (jpdatetime(2023, 10, 30), "%E, %B %d", "Reiwa 05, October 30"),
-            (jpdatetime(2018, 4, 1), "%E, %B %d", "Heisei 30, April 01"),
-            (jpdatetime(1989, 1, 7), "%E, %B %d", "Showa 64, January 07"),
-            (jpdatetime(1912, 7, 30), "%E, %B %d", "Taisho 01, July 30"),
-            (jpdatetime(1912, 7, 29), "%E, %B %d", "Meiji 45, July 29"),
-            # Additional test cases with zero-padded years
+            (jpdatetime(2023, 10, 30), "%-E, %B %d", "Reiwa 5, October 30"),
             (jpdatetime(2019, 5, 1), "%E, %B %d", "Reiwa 01, May 01"),
+            (jpdatetime(2019, 5, 1), "%-E, %B %d", "Reiwa 1, May 01"),
+            # Heisei Era
+            (jpdatetime(2018, 4, 1), "%E, %B %d", "Heisei 30, April 01"),
+            (jpdatetime(2018, 4, 1), "%-E, %B %d", "Heisei 30, April 01"),
             (jpdatetime(1989, 1, 8), "%E, %B %d", "Heisei 01, January 08"),
+            (jpdatetime(1989, 1, 8), "%-E, %B %d", "Heisei 1, January 08"),
+            # Showa Era
+            (jpdatetime(1989, 1, 7), "%E, %B %d", "Showa 64, January 07"),
+            (jpdatetime(1989, 1, 7), "%-E, %B %d", "Showa 64, January 07"),
             (jpdatetime(1926, 12, 25), "%E, %B %d", "Showa 01, December 25"),
+            (jpdatetime(1926, 12, 25), "%-E, %B %d", "Showa 1, December 25"),
+            # Taisho Era
+            (jpdatetime(1926, 12, 24), "%E, %B %d", "Taisho 15, December 24"),
+            (jpdatetime(1926, 12, 24), "%-E, %B %d", "Taisho 15, December 24"),
+            (jpdatetime(1912, 7, 30), "%E, %B %d", "Taisho 01, July 30"),
+            (jpdatetime(1912, 7, 30), "%-E, %B %d", "Taisho 1, July 30"),
+            # Meiji Era
+            (jpdatetime(1912, 7, 29), "%E, %B %d", "Meiji 45, July 29"),
+            (jpdatetime(1912, 7, 29), "%-E, %B %d", "Meiji 45, July 29"),
             (jpdatetime(1868, 9, 8), "%E, %B %d", "Meiji 01, September 08"),
-            # Edge case: Date just before an era change
-            (jpdatetime(2019, 4, 30), "%E, %B %d", "Heisei 31, April 30"),
-            # Leap year
-            (jpdatetime(1992, 2, 29), "%E, %B %d", "Heisei 04, February 29"),
+            (jpdatetime(1868, 9, 8), "%-E, %B %d", "Meiji 1, September 08"),
         ]
 
-        # Separate test cases for strftime (%e)
+        # Test cases for strftime with %e format (Abbreviated English Era Name)
         self.test_cases_strftime_e = [
-            # Existing test cases with zero-padded years
+            # Reiwa Era
             (jpdatetime(2023, 10, 30), "%e/%m/%d", "R05/10/30"),
-            (jpdatetime(2018, 4, 1), "%e/%m/%d", "H30/04/01"),
-            (jpdatetime(1989, 1, 7), "%e/%m/%d", "S64/01/07"),
-            (jpdatetime(1912, 7, 30), "%e/%m/%d", "T01/07/30"),
-            (jpdatetime(1912, 7, 29), "%e/%m/%d", "M45/07/29"),
-            # Additional test cases with zero-padded years
+            (jpdatetime(2023, 10, 30), "%-e/%m/%d", "R5/10/30"),
             (jpdatetime(2019, 5, 1), "%e/%m/%d", "R01/05/01"),
+            (jpdatetime(2019, 5, 1), "%-e/%m/%d", "R1/05/01"),
+            # Heisei Era
+            (jpdatetime(2018, 4, 1), "%e/%m/%d", "H30/04/01"),
+            (jpdatetime(2018, 4, 1), "%-e/%m/%d", "H30/04/01"),
             (jpdatetime(1989, 1, 8), "%e/%m/%d", "H01/01/08"),
+            (jpdatetime(1989, 1, 8), "%-e/%m/%d", "H1/01/08"),
+            # Showa Era
+            (jpdatetime(1989, 1, 7), "%e/%m/%d", "S64/01/07"),
+            (jpdatetime(1989, 1, 7), "%-e/%m/%d", "S64/01/07"),
             (jpdatetime(1926, 12, 25), "%e/%m/%d", "S01/12/25"),
+            (jpdatetime(1926, 12, 25), "%-e/%m/%d", "S1/12/25"),
+            # Taisho Era
+            (jpdatetime(1926, 12, 24), "%e/%m/%d", "T15/12/24"),
+            (jpdatetime(1926, 12, 24), "%-e/%m/%d", "T15/12/24"),
+            (jpdatetime(1912, 7, 30), "%e/%m/%d", "T01/07/30"),
+            (jpdatetime(1912, 7, 30), "%-e/%m/%d", "T1/07/30"),
+            # Meiji Era
+            (jpdatetime(1912, 7, 29), "%e/%m/%d", "M45/07/29"),
+            (jpdatetime(1912, 7, 29), "%-e/%m/%d", "M45/07/29"),
             (jpdatetime(1868, 9, 8), "%e/%m/%d", "M01/09/08"),
-            # Edge case: Date just before an era change
-            (jpdatetime(2019, 4, 30), "%e/%m/%d", "H31/04/30"),
-            # Leap year
-            (jpdatetime(1992, 2, 29), "%e/%m/%d", "H04/02/29"),
+            (jpdatetime(1868, 9, 8), "%-e/%m/%d", "M1/09/08"),
         ]
 
-    def test_strptime_full_jpEra(self):
-        for date_string, format_string, expected_date in self.test_cases_strptime_G:
-            with self.subTest(date_string=date_string):
-                self.assertEqual(jpdatetime.strptime(date_string, format_string), expected_date)
+        # Test cases for strptime with %G format
+        self.test_cases_strptime_G = [
+            # Reiwa Era
+            ("令和05年10月30日", "%G年%m月%d日", jpdatetime(2023, 10, 30)),
+            ("令和5年10月30日", "%-G年%m月%d日", jpdatetime(2023, 10, 30)),
+            ("令和元年05月01日", "%G年%m月%d日", jpdatetime(2019, 5, 1)),
+            ("令和元年05月01日", "%-G年%m月%d日", jpdatetime(2019, 5, 1)),
+            # Heisei Era
+            ("平成30年04月01日", "%G年%m月%d日", jpdatetime(2018, 4, 1)),
+            ("平成30年04月01日", "%-G年%m月%d日", jpdatetime(2018, 4, 1)),
+            ("平成元年01月08日", "%G年%m月%d日", jpdatetime(1989, 1, 8)),
+            ("平成元年01月08日", "%-G年%m月%d日", jpdatetime(1989, 1, 8)),
+            # Showa Era
+            ("昭和64年01月07日", "%G年%m月%d日", jpdatetime(1989, 1, 7)),
+            ("昭和64年01月07日", "%-G年%m月%d日", jpdatetime(1989, 1, 7)),
+            ("昭和元年12月25日", "%G年%m月%d日", jpdatetime(1926, 12, 25)),
+            ("昭和元年12月25日", "%-G年%m月%d日", jpdatetime(1926, 12, 25)),
+            # Taisho Era
+            ("大正15年12月24日", "%G年%m月%d日", jpdatetime(1926, 12, 24)),
+            ("大正15年12月24日", "%-G年%m月%d日", jpdatetime(1926, 12, 24)),
+            ("大正元年07月30日", "%G年%m月%d日", jpdatetime(1912, 7, 30)),
+            ("大正元年07月30日", "%-G年%m月%d日", jpdatetime(1912, 7, 30)),
+            # Meiji Era
+            ("明治45年07月29日", "%G年%m月%d日", jpdatetime(1912, 7, 29)),
+            ("明治45年07月29日", "%-G年%m月%d日", jpdatetime(1912, 7, 29)),
+            ("明治元年09月08日", "%G年%m月%d日", jpdatetime(1868, 9, 8)),
+            ("明治元年09月08日", "%-G年%m月%d日", jpdatetime(1868, 9, 8)),
+        ]
 
-    def test_strptime_abbr_jpEra(self):
-        for date_string, format_string, expected_date in self.test_cases_strptime_g:
-            with self.subTest(date_string=date_string):
-                self.assertEqual(jpdatetime.strptime(date_string, format_string), expected_date)
+        # Similar test cases for strptime with %g, %E, %e
+        # Test cases for strptime with %g format
+        self.test_cases_strptime_g = [
+            # Reiwa Era
+            ("令05年10月30日", "%g年%m月%d日", jpdatetime(2023, 10, 30)),
+            ("令5年10月30日", "%-g年%m月%d日", jpdatetime(2023, 10, 30)),
+            ("令01年05月01日", "%g年%m月%d日", jpdatetime(2019, 5, 1)),
+            ("令1年05月01日", "%-g年%m月%d日", jpdatetime(2019, 5, 1)),
+            # Heisei Era
+            ("平30年04月01日", "%g年%m月%d日", jpdatetime(2018, 4, 1)),
+            ("平30年04月01日", "%-g年%m月%d日", jpdatetime(2018, 4, 1)),
+            ("平01年01月08日", "%g年%m月%d日", jpdatetime(1989, 1, 8)),
+            ("平1年01月08日", "%-g年%m月%d日", jpdatetime(1989, 1, 8)),
+            # Showa Era
+            ("昭64年01月07日", "%g年%m月%d日", jpdatetime(1989, 1, 7)),
+            ("昭64年01月07日", "%-g年%m月%d日", jpdatetime(1989, 1, 7)),
+            ("昭01年12月25日", "%g年%m月%d日", jpdatetime(1926, 12, 25)),
+            ("昭1年12月25日", "%-g年%m月%d日", jpdatetime(1926, 12, 25)),
+            # Taisho Era
+            ("大15年12月24日", "%g年%m月%d日", jpdatetime(1926, 12, 24)),
+            ("大15年12月24日", "%-g年%m月%d日", jpdatetime(1926, 12, 24)),
+            ("大01年07月30日", "%g年%m月%d日", jpdatetime(1912, 7, 30)),
+            ("大1年07月30日", "%-g年%m月%d日", jpdatetime(1912, 7, 30)),
+            # Meiji Era
+            ("明45年07月29日", "%g年%m月%d日", jpdatetime(1912, 7, 29)),
+            ("明45年07月29日", "%-g年%m月%d日", jpdatetime(1912, 7, 29)),
+            ("明01年09月08日", "%g年%m月%d日", jpdatetime(1868, 9, 8)),
+            ("明1年09月08日", "%-g年%m月%d日", jpdatetime(1868, 9, 8)),
+        ]
 
-    def test_strptime_full_enEra(self):
-        for date_string, format_string, expected_date in self.test_cases_strptime_E:
-            with self.subTest(date_string=date_string):
-                self.assertEqual(jpdatetime.strptime(date_string, format_string), expected_date)
+        # Test cases for strptime with %E format
+        self.test_cases_strptime_E = [
+            # Reiwa Era
+            ("Reiwa 05, October 30", "%E, %B %d", jpdatetime(2023, 10, 30)),
+            ("Reiwa 5, October 30", "%-E, %B %d", jpdatetime(2023, 10, 30)),
+            ("Reiwa 01, May 01", "%E, %B %d", jpdatetime(2019, 5, 1)),
+            ("Reiwa 1, May 01", "%-E, %B %d", jpdatetime(2019, 5, 1)),
+            # Heisei Era
+            ("Heisei 30, April 01", "%E, %B %d", jpdatetime(2018, 4, 1)),
+            ("Heisei 30, April 01", "%-E, %B %d", jpdatetime(2018, 4, 1)),
+            ("Heisei 01, January 08", "%E, %B %d", jpdatetime(1989, 1, 8)),
+            ("Heisei 1, January 08", "%-E, %B %d", jpdatetime(1989, 1, 8)),
+            # Showa Era
+            ("Showa 64, January 07", "%E, %B %d", jpdatetime(1989, 1, 7)),
+            ("Showa 64, January 07", "%-E, %B %d", jpdatetime(1989, 1, 7)),
+            ("Showa 01, December 25", "%E, %B %d", jpdatetime(1926, 12, 25)),
+            ("Showa 1, December 25", "%-E, %B %d", jpdatetime(1926, 12, 25)),
+            # Taisho Era
+            ("Taisho 15, December 24", "%E, %B %d", jpdatetime(1926, 12, 24)),
+            ("Taisho 15, December 24", "%-E, %B %d", jpdatetime(1926, 12, 24)),
+            ("Taisho 01, July 30", "%E, %B %d", jpdatetime(1912, 7, 30)),
+            ("Taisho 1, July 30", "%-E, %B %d", jpdatetime(1912, 7, 30)),
+            # Meiji Era
+            ("Meiji 45, July 29", "%E, %B %d", jpdatetime(1912, 7, 29)),
+            ("Meiji 45, July 29", "%-E, %B %d", jpdatetime(1912, 7, 29)),
+            ("Meiji 01, September 08", "%E, %B %d", jpdatetime(1868, 9, 8)),
+            ("Meiji 1, September 08", "%-E, %B %d", jpdatetime(1868, 9, 8)),
+        ]
 
-    def test_strptime_abbr_enEra(self):
-        for date_string, format_string, expected_date in self.test_cases_strptime_e:
-            with self.subTest(date_string=date_string):
-                self.assertEqual(jpdatetime.strptime(date_string, format_string), expected_date)
+        # Test cases for strptime with %e format
+        self.test_cases_strptime_e = [
+            # Reiwa Era
+            ("R05/10/30", "%e/%m/%d", jpdatetime(2023, 10, 30)),
+            ("R5/10/30", "%-e/%m/%d", jpdatetime(2023, 10, 30)),
+            ("R01/05/01", "%e/%m/%d", jpdatetime(2019, 5, 1)),
+            ("R1/05/01", "%-e/%m/%d", jpdatetime(2019, 5, 1)),
+            # Heisei Era
+            ("H30/04/01", "%e/%m/%d", jpdatetime(2018, 4, 1)),
+            ("H30/04/01", "%-e/%m/%d", jpdatetime(2018, 4, 1)),
+            ("H01/01/08", "%e/%m/%d", jpdatetime(1989, 1, 8)),
+            ("H1/01/08", "%-e/%m/%d", jpdatetime(1989, 1, 8)),
+            # Showa Era
+            ("S64/01/07", "%e/%m/%d", jpdatetime(1989, 1, 7)),
+            ("S64/01/07", "%-e/%m/%d", jpdatetime(1989, 1, 7)),
+            ("S01/12/25", "%e/%m/%d", jpdatetime(1926, 12, 25)),
+            ("S1/12/25", "%-e/%m/%d", jpdatetime(1926, 12, 25)),
+            # Taisho Era
+            ("T15/12/24", "%e/%m/%d", jpdatetime(1926, 12, 24)),
+            ("T15/12/24", "%-e/%m/%d", jpdatetime(1926, 12, 24)),
+            ("T01/07/30", "%e/%m/%d", jpdatetime(1912, 7, 30)),
+            ("T1/07/30", "%-e/%m/%d", jpdatetime(1912, 7, 30)),
+            # Meiji Era
+            ("M45/07/29", "%e/%m/%d", jpdatetime(1912, 7, 29)),
+            ("M45/07/29", "%-e/%m/%d", jpdatetime(1912, 7, 29)),
+            ("M01/09/08", "%e/%m/%d", jpdatetime(1868, 9, 8)),
+            ("M1/09/08", "%-e/%m/%d", jpdatetime(1868, 9, 8)),
+        ]
 
     def test_strftime_full_jpEra(self):
         for date, format_string, expected_output in self.test_cases_strftime_G:
-            with self.subTest(date=date):
+            with self.subTest(date=date, format_string=format_string):
                 self.assertEqual(date.strftime(format_string), expected_output)
 
     def test_strftime_abbr_jpEra(self):
         for date, format_string, expected_output in self.test_cases_strftime_g:
-            with self.subTest(date=date):
+            with self.subTest(date=date, format_string=format_string):
                 self.assertEqual(date.strftime(format_string), expected_output)
 
     def test_strftime_full_enEra(self):
         for date, format_string, expected_output in self.test_cases_strftime_E:
-            with self.subTest(date=date):
+            with self.subTest(date=date, format_string=format_string):
                 self.assertEqual(date.strftime(format_string), expected_output)
 
     def test_strftime_abbr_enEra(self):
         for date, format_string, expected_output in self.test_cases_strftime_e:
-            with self.subTest(date=date):
+            with self.subTest(date=date, format_string=format_string):
                 self.assertEqual(date.strftime(format_string), expected_output)
+
+    def test_strptime_full_jpEra(self):
+        for date_string, format_string, expected_date in self.test_cases_strptime_G:
+            with self.subTest(date_string=date_string, format_string=format_string):
+                result = jpdatetime.strptime(date_string, format_string)
+                self.assertEqual(result, expected_date)
+
+    def test_strptime_abbr_jpEra(self):
+        for date_string, format_string, expected_date in self.test_cases_strptime_g:
+            with self.subTest(date_string=date_string, format_string=format_string):
+                result = jpdatetime.strptime(date_string, format_string)
+                self.assertEqual(result, expected_date)
+
+    def test_strptime_full_enEra(self):
+        for date_string, format_string, expected_date in self.test_cases_strptime_E:
+            with self.subTest(date_string=date_string, format_string=format_string):
+                result = jpdatetime.strptime(date_string, format_string)
+                self.assertEqual(result, expected_date)
+
+    def test_strptime_abbr_enEra(self):
+        for date_string, format_string, expected_date in self.test_cases_strptime_e:
+            with self.subTest(date_string=date_string, format_string=format_string):
+                result = jpdatetime.strptime(date_string, format_string)
+                self.assertEqual(result, expected_date)
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_jpdatetime.py
+++ b/test/test_jpdatetime.py
@@ -22,8 +22,6 @@ class Testjpdatetime(unittest.TestCase):
             ("明治元年9月8日", "%G年%m月%d日", datetime(1868, 9, 8)),
             # Edge case: Date just before an era change
             ("平成31年4月30日", "%G年%m月%d日", datetime(2019, 4, 30)),
-            # Edge case: Era start date
-            ("令和元年5月1日", "%G年%m月%d日", datetime(2019, 5, 1)),
             # Leap year
             ("平成4年2月29日", "%G年%m月%d日", datetime(1992, 2, 29)),
         ]
@@ -90,79 +88,79 @@ class Testjpdatetime(unittest.TestCase):
 
         # Separate test cases for strftime (%G)
         self.test_cases_strftime_G = [
-            # Existing test cases
-            (jpdatetime(2024, 10, 30), "%G年%m月%d日", "令和6年10月30日"),
+            # Existing test cases with zero-padded years
+            (jpdatetime(2024, 10, 30), "%G年%m月%d日", "令和06年10月30日"),
             (jpdatetime(2018, 4, 1), "%G年%m月%d日", "平成30年04月01日"),
             (jpdatetime(1989, 1, 7), "%G年%m月%d日", "昭和64年01月07日"),
             (jpdatetime(1926, 12, 24), "%G年%m月%d日", "大正15年12月24日"),
             (jpdatetime(1912, 7, 29), "%G年%m月%d日", "明治45年07月29日"),
             (jpdatetime(2019, 5, 1), "%G年%m月%d日", "令和元年05月01日"),
             (jpdatetime(1989, 1, 8), "%G年%m月%d日", "平成元年01月08日"),
-            # Additional test cases
+            # Additional test cases with zero-padded years
             (jpdatetime(1926, 12, 25), "%G年%m月%d日", "昭和元年12月25日"),
             (jpdatetime(1912, 7, 30), "%G年%m月%d日", "大正元年07月30日"),
             (jpdatetime(1868, 9, 8), "%G年%m月%d日", "明治元年09月08日"),
             # Edge case: Date just before an era change
             (jpdatetime(2019, 4, 30), "%G年%m月%d日", "平成31年04月30日"),
             # Leap year
-            (jpdatetime(1992, 2, 29), "%G年%m月%d日", "平成4年02月29日"),
+            (jpdatetime(1992, 2, 29), "%G年%m月%d日", "平成04年02月29日"),
         ]
 
         # Separate test cases for strftime (%g)
         self.test_cases_strftime_g = [
-            # Existing test cases
-            (jpdatetime(2023, 10, 30), "%g年%m月%d日", "令5年10月30日"),
+            # Existing test cases with zero-padded years
+            (jpdatetime(2023, 10, 30), "%g年%m月%d日", "令05年10月30日"),
             (jpdatetime(2018, 4, 1), "%g年%m月%d日", "平30年04月01日"),
             (jpdatetime(1989, 1, 7), "%g年%m月%d日", "昭64年01月07日"),
-            (jpdatetime(1912, 7, 30), "%g年%m月%d日", "大1年07月30日"),
+            (jpdatetime(1912, 7, 30), "%g年%m月%d日", "大01年07月30日"),
             (jpdatetime(1912, 7, 29), "%g年%m月%d日", "明45年07月29日"),
-            # Additional test cases
-            (jpdatetime(2019, 5, 1), "%g年%m月%d日", "令1年05月01日"),
-            (jpdatetime(1989, 1, 8), "%g年%m月%d日", "平1年01月08日"),
-            (jpdatetime(1926, 12, 25), "%g年%m月%d日", "昭1年12月25日"),
-            (jpdatetime(1868, 9, 8), "%g年%m月%d日", "明1年09月08日"),
+            # Additional test cases with zero-padded years
+            (jpdatetime(2019, 5, 1), "%g年%m月%d日", "令01年05月01日"),
+            (jpdatetime(1989, 1, 8), "%g年%m月%d日", "平01年01月08日"),
+            (jpdatetime(1926, 12, 25), "%g年%m月%d日", "昭01年12月25日"),
+            (jpdatetime(1868, 9, 8), "%g年%m月%d日", "明01年09月08日"),
             # Edge case: Date just before an era change
             (jpdatetime(2019, 4, 30), "%g年%m月%d日", "平31年04月30日"),
             # Leap year
-            (jpdatetime(1992, 2, 29), "%g年%m月%d日", "平4年02月29日"),
+            (jpdatetime(1992, 2, 29), "%g年%m月%d日", "平04年02月29日"),
         ]
 
         # Separate test cases for strftime (%E)
         self.test_cases_strftime_E = [
-            # Existing test cases
-            (jpdatetime(2023, 10, 30), "%E, %B %d", "Reiwa 5, October 30"),
+            # Existing test cases with zero-padded years
+            (jpdatetime(2023, 10, 30), "%E, %B %d", "Reiwa 05, October 30"),
             (jpdatetime(2018, 4, 1), "%E, %B %d", "Heisei 30, April 01"),
             (jpdatetime(1989, 1, 7), "%E, %B %d", "Showa 64, January 07"),
-            (jpdatetime(1912, 7, 30), "%E, %B %d", "Taisho 1, July 30"),
+            (jpdatetime(1912, 7, 30), "%E, %B %d", "Taisho 01, July 30"),
             (jpdatetime(1912, 7, 29), "%E, %B %d", "Meiji 45, July 29"),
-            # Additional test cases
-            (jpdatetime(2019, 5, 1), "%E, %B %d", "Reiwa 1, May 01"),
-            (jpdatetime(1989, 1, 8), "%E, %B %d", "Heisei 1, January 08"),
-            (jpdatetime(1926, 12, 25), "%E, %B %d", "Showa 1, December 25"),
-            (jpdatetime(1868, 9, 8), "%E, %B %d", "Meiji 1, September 08"),
+            # Additional test cases with zero-padded years
+            (jpdatetime(2019, 5, 1), "%E, %B %d", "Reiwa 01, May 01"),
+            (jpdatetime(1989, 1, 8), "%E, %B %d", "Heisei 01, January 08"),
+            (jpdatetime(1926, 12, 25), "%E, %B %d", "Showa 01, December 25"),
+            (jpdatetime(1868, 9, 8), "%E, %B %d", "Meiji 01, September 08"),
             # Edge case: Date just before an era change
             (jpdatetime(2019, 4, 30), "%E, %B %d", "Heisei 31, April 30"),
             # Leap year
-            (jpdatetime(1992, 2, 29), "%E, %B %d", "Heisei 4, February 29"),
+            (jpdatetime(1992, 2, 29), "%E, %B %d", "Heisei 04, February 29"),
         ]
 
         # Separate test cases for strftime (%e)
         self.test_cases_strftime_e = [
-            # Existing test cases
-            (jpdatetime(2023, 10, 30), "%e/%m/%d", "R5/10/30"),
+            # Existing test cases with zero-padded years
+            (jpdatetime(2023, 10, 30), "%e/%m/%d", "R05/10/30"),
             (jpdatetime(2018, 4, 1), "%e/%m/%d", "H30/04/01"),
             (jpdatetime(1989, 1, 7), "%e/%m/%d", "S64/01/07"),
-            (jpdatetime(1912, 7, 30), "%e/%m/%d", "T1/07/30"),
+            (jpdatetime(1912, 7, 30), "%e/%m/%d", "T01/07/30"),
             (jpdatetime(1912, 7, 29), "%e/%m/%d", "M45/07/29"),
-            # Additional test cases
-            (jpdatetime(2019, 5, 1), "%e/%m/%d", "R1/05/01"),
-            (jpdatetime(1989, 1, 8), "%e/%m/%d", "H1/01/08"),
-            (jpdatetime(1926, 12, 25), "%e/%m/%d", "S1/12/25"),
-            (jpdatetime(1868, 9, 8), "%e/%m/%d", "M1/09/08"),
+            # Additional test cases with zero-padded years
+            (jpdatetime(2019, 5, 1), "%e/%m/%d", "R01/05/01"),
+            (jpdatetime(1989, 1, 8), "%e/%m/%d", "H01/01/08"),
+            (jpdatetime(1926, 12, 25), "%e/%m/%d", "S01/12/25"),
+            (jpdatetime(1868, 9, 8), "%e/%m/%d", "M01/09/08"),
             # Edge case: Date just before an era change
             (jpdatetime(2019, 4, 30), "%e/%m/%d", "H31/04/30"),
             # Leap year
-            (jpdatetime(1992, 2, 29), "%e/%m/%d", "H4/02/29"),
+            (jpdatetime(1992, 2, 29), "%e/%m/%d", "H04/02/29"),
         ]
 
     def test_strptime_full_jpEra(self):

--- a/test/test_jpdatetime.py
+++ b/test/test_jpdatetime.py
@@ -4,24 +4,93 @@ from jpdatetime import jpdatetime
 
 class Testjpdatetime(unittest.TestCase):
     def setUp(self):
-        self.test_cases_strptime = [
+        # Test cases for %G format (Full Japanese Era Name)
+        self.test_cases_strptime_G = [
+            # Existing test cases
             ("令和5年10月30日", "%G年%m月%d日", datetime(2023, 10, 30)),
             ("平成30年4月1日", "%G年%m月%d日", datetime(2018, 4, 1)),
             ("昭和64年1月7日", "%G年%m月%d日", datetime(1989, 1, 7)),
             ("大正15年12月24日", "%G年%m月%d日", datetime(1926, 12, 24)),
             ("明治45年7月29日", "%G年%m月%d日", datetime(1912, 7, 29)),
-            ("令和1年5月1日", "%G年%m月%d日", datetime(2019, 5, 1)),
-            ("平成1年1月8日", "%G年%m月%d日", datetime(1989, 1, 8)),
             ("令和元年5月1日", "%G年%m月%d日", datetime(2019, 5, 1)),
             ("平成元年1月8日", "%G年%m月%d日", datetime(1989, 1, 8)),
+            # Additional test cases
+            ("令和6年1月1日", "%G年%m月%d日", datetime(2024, 1, 1)),
+            ("平成元年12月31日", "%G年%m月%d日", datetime(1989, 12, 31)),
+            ("昭和元年12月25日", "%G年%m月%d日", datetime(1926, 12, 25)),
+            ("大正元年7月30日", "%G年%m月%d日", datetime(1912, 7, 30)),
+            ("明治元年9月8日", "%G年%m月%d日", datetime(1868, 9, 8)),
+            # Edge case: Date just before an era change
+            ("平成31年4月30日", "%G年%m月%d日", datetime(2019, 4, 30)),
+            # Edge case: Era start date
+            ("令和元年5月1日", "%G年%m月%d日", datetime(2019, 5, 1)),
+            # Leap year
+            ("平成4年2月29日", "%G年%m月%d日", datetime(1992, 2, 29)),
+        ]
+
+        # Test cases for %g format (Abbreviated Japanese Era Name)
+        self.test_cases_strptime_g = [
+            # Existing test cases
             ("令5年10月30日", "%g年%m月%d日", datetime(2023, 10, 30)),
             ("平30年4月1日", "%g年%m月%d日", datetime(2018, 4, 1)),
             ("昭64年1月7日", "%g年%m月%d日", datetime(1989, 1, 7)),
             ("大1年7月30日", "%g年%m月%d日", datetime(1912, 7, 30)),
-            ("明45年7月29日", "%g年%m月%d日", datetime(1912, 7, 29))
+            ("明45年7月29日", "%g年%m月%d日", datetime(1912, 7, 29)),
+            # Additional test cases
+            ("令1年5月1日", "%g年%m月%d日", datetime(2019, 5, 1)),
+            ("平1年1月8日", "%g年%m月%d日", datetime(1989, 1, 8)),
+            ("昭1年12月25日", "%g年%m月%d日", datetime(1926, 12, 25)),
+            ("大元年7月30日", "%g年%m月%d日", datetime(1912, 7, 30)),
+            ("明元年9月8日", "%g年%m月%d日", datetime(1868, 9, 8)),
+            # Edge case: Date just before an era change
+            ("平31年4月30日", "%g年%m月%d日", datetime(2019, 4, 30)),
+            # Leap year
+            ("平4年2月29日", "%g年%m月%d日", datetime(1992, 2, 29)),
         ]
 
-        self.test_cases_strftime = [
+        # Test cases for %E format (Full English Era Name)
+        self.test_cases_strptime_E = [
+            # Existing test cases
+            ("Reiwa 5, October 30", "%E, %B %d", datetime(2023, 10, 30)),
+            ("Heisei 30, April 1", "%E, %B %d", datetime(2018, 4, 1)),
+            ("Showa 64, January 7", "%E, %B %d", datetime(1989, 1, 7)),
+            ("Taisho 15, December 24", "%E, %B %d", datetime(1926, 12, 24)),
+            ("Meiji 45, July 29", "%E, %B %d", datetime(1912, 7, 29)),
+            # Additional test cases
+            ("Reiwa 1, May 1", "%E, %B %d", datetime(2019, 5, 1)),
+            ("Heisei 1, January 8", "%E, %B %d", datetime(1989, 1, 8)),
+            ("Showa 1, December 25", "%E, %B %d", datetime(1926, 12, 25)),
+            ("Taisho 1, July 30", "%E, %B %d", datetime(1912, 7, 30)),
+            ("Meiji 1, September 8", "%E, %B %d", datetime(1868, 9, 8)),
+            # Edge case: Date just before an era change
+            ("Heisei 31, April 30", "%E, %B %d", datetime(2019, 4, 30)),
+            # Leap year
+            ("Heisei 4, February 29", "%E, %B %d", datetime(1992, 2, 29)),
+        ]
+
+        # Test cases for %e format (Abbreviated English Era Name)
+        self.test_cases_strptime_e = [
+            # Existing test cases
+            ("R5/10/30", "%e/%m/%d", datetime(2023, 10, 30)),
+            ("H30/4/1", "%e/%m/%d", datetime(2018, 4, 1)),
+            ("S64/1/7", "%e/%m/%d", datetime(1989, 1, 7)),
+            ("T15/12/24", "%e/%m/%d", datetime(1926, 12, 24)),
+            ("M45/7/29", "%e/%m/%d", datetime(1912, 7, 29)),
+            # Additional test cases
+            ("R1/5/1", "%e/%m/%d", datetime(2019, 5, 1)),
+            ("H1/1/8", "%e/%m/%d", datetime(1989, 1, 8)),
+            ("S1/12/25", "%e/%m/%d", datetime(1926, 12, 25)),
+            ("T1/7/30", "%e/%m/%d", datetime(1912, 7, 30)),
+            ("M1/9/8", "%e/%m/%d", datetime(1868, 9, 8)),
+            # Edge case: Date just before an era change
+            ("H31/4/30", "%e/%m/%d", datetime(2019, 4, 30)),
+            # Leap year
+            ("H4/02/29", "%e/%m/%d", datetime(1992, 2, 29)),
+        ]
+
+        # Separate test cases for strftime (%G)
+        self.test_cases_strftime_G = [
+            # Existing test cases
             (jpdatetime(2024, 10, 30), "%G年%m月%d日", "令和6年10月30日"),
             (jpdatetime(2018, 4, 1), "%G年%m月%d日", "平成30年04月01日"),
             (jpdatetime(1989, 1, 7), "%G年%m月%d日", "昭和64年01月07日"),
@@ -29,20 +98,110 @@ class Testjpdatetime(unittest.TestCase):
             (jpdatetime(1912, 7, 29), "%G年%m月%d日", "明治45年07月29日"),
             (jpdatetime(2019, 5, 1), "%G年%m月%d日", "令和元年05月01日"),
             (jpdatetime(1989, 1, 8), "%G年%m月%d日", "平成元年01月08日"),
+            # Additional test cases
+            (jpdatetime(1926, 12, 25), "%G年%m月%d日", "昭和元年12月25日"),
+            (jpdatetime(1912, 7, 30), "%G年%m月%d日", "大正元年07月30日"),
+            (jpdatetime(1868, 9, 8), "%G年%m月%d日", "明治元年09月08日"),
+            # Edge case: Date just before an era change
+            (jpdatetime(2019, 4, 30), "%G年%m月%d日", "平成31年04月30日"),
+            # Leap year
+            (jpdatetime(1992, 2, 29), "%G年%m月%d日", "平成4年02月29日"),
+        ]
+
+        # Separate test cases for strftime (%g)
+        self.test_cases_strftime_g = [
+            # Existing test cases
             (jpdatetime(2023, 10, 30), "%g年%m月%d日", "令5年10月30日"),
             (jpdatetime(2018, 4, 1), "%g年%m月%d日", "平30年04月01日"),
             (jpdatetime(1989, 1, 7), "%g年%m月%d日", "昭64年01月07日"),
             (jpdatetime(1912, 7, 30), "%g年%m月%d日", "大1年07月30日"),
-            (jpdatetime(1912, 7, 29), "%g年%m月%d日", "明45年07月29日")
+            (jpdatetime(1912, 7, 29), "%g年%m月%d日", "明45年07月29日"),
+            # Additional test cases
+            (jpdatetime(2019, 5, 1), "%g年%m月%d日", "令1年05月01日"),
+            (jpdatetime(1989, 1, 8), "%g年%m月%d日", "平1年01月08日"),
+            (jpdatetime(1926, 12, 25), "%g年%m月%d日", "昭1年12月25日"),
+            (jpdatetime(1868, 9, 8), "%g年%m月%d日", "明1年09月08日"),
+            # Edge case: Date just before an era change
+            (jpdatetime(2019, 4, 30), "%g年%m月%d日", "平31年04月30日"),
+            # Leap year
+            (jpdatetime(1992, 2, 29), "%g年%m月%d日", "平4年02月29日"),
         ]
 
-    def test_strptime(self):
-        for date_string, format_string, expected_date in self.test_cases_strptime:
+        # Separate test cases for strftime (%E)
+        self.test_cases_strftime_E = [
+            # Existing test cases
+            (jpdatetime(2023, 10, 30), "%E, %B %d", "Reiwa 5, October 30"),
+            (jpdatetime(2018, 4, 1), "%E, %B %d", "Heisei 30, April 01"),
+            (jpdatetime(1989, 1, 7), "%E, %B %d", "Showa 64, January 07"),
+            (jpdatetime(1912, 7, 30), "%E, %B %d", "Taisho 1, July 30"),
+            (jpdatetime(1912, 7, 29), "%E, %B %d", "Meiji 45, July 29"),
+            # Additional test cases
+            (jpdatetime(2019, 5, 1), "%E, %B %d", "Reiwa 1, May 01"),
+            (jpdatetime(1989, 1, 8), "%E, %B %d", "Heisei 1, January 08"),
+            (jpdatetime(1926, 12, 25), "%E, %B %d", "Showa 1, December 25"),
+            (jpdatetime(1868, 9, 8), "%E, %B %d", "Meiji 1, September 08"),
+            # Edge case: Date just before an era change
+            (jpdatetime(2019, 4, 30), "%E, %B %d", "Heisei 31, April 30"),
+            # Leap year
+            (jpdatetime(1992, 2, 29), "%E, %B %d", "Heisei 4, February 29"),
+        ]
+
+        # Separate test cases for strftime (%e)
+        self.test_cases_strftime_e = [
+            # Existing test cases
+            (jpdatetime(2023, 10, 30), "%e/%m/%d", "R5/10/30"),
+            (jpdatetime(2018, 4, 1), "%e/%m/%d", "H30/04/01"),
+            (jpdatetime(1989, 1, 7), "%e/%m/%d", "S64/01/07"),
+            (jpdatetime(1912, 7, 30), "%e/%m/%d", "T1/07/30"),
+            (jpdatetime(1912, 7, 29), "%e/%m/%d", "M45/07/29"),
+            # Additional test cases
+            (jpdatetime(2019, 5, 1), "%e/%m/%d", "R1/05/01"),
+            (jpdatetime(1989, 1, 8), "%e/%m/%d", "H1/01/08"),
+            (jpdatetime(1926, 12, 25), "%e/%m/%d", "S1/12/25"),
+            (jpdatetime(1868, 9, 8), "%e/%m/%d", "M1/09/08"),
+            # Edge case: Date just before an era change
+            (jpdatetime(2019, 4, 30), "%e/%m/%d", "H31/04/30"),
+            # Leap year
+            (jpdatetime(1992, 2, 29), "%e/%m/%d", "H4/02/29"),
+        ]
+
+    def test_strptime_full_jpEra(self):
+        for date_string, format_string, expected_date in self.test_cases_strptime_G:
             with self.subTest(date_string=date_string):
                 self.assertEqual(jpdatetime.strptime(date_string, format_string), expected_date)
 
-    def test_strftime(self):
-        for date, format_string, expected_output in self.test_cases_strftime:
+    def test_strptime_abbr_jpEra(self):
+        for date_string, format_string, expected_date in self.test_cases_strptime_g:
+            with self.subTest(date_string=date_string):
+                self.assertEqual(jpdatetime.strptime(date_string, format_string), expected_date)
+
+    def test_strptime_full_enEra(self):
+        for date_string, format_string, expected_date in self.test_cases_strptime_E:
+            with self.subTest(date_string=date_string):
+                self.assertEqual(jpdatetime.strptime(date_string, format_string), expected_date)
+
+    def test_strptime_abbr_enEra(self):
+        for date_string, format_string, expected_date in self.test_cases_strptime_e:
+            with self.subTest(date_string=date_string):
+                self.assertEqual(jpdatetime.strptime(date_string, format_string), expected_date)
+
+    def test_strftime_full_jpEra(self):
+        for date, format_string, expected_output in self.test_cases_strftime_G:
+            with self.subTest(date=date):
+                self.assertEqual(date.strftime(format_string), expected_output)
+
+    def test_strftime_abbr_jpEra(self):
+        for date, format_string, expected_output in self.test_cases_strftime_g:
+            with self.subTest(date=date):
+                self.assertEqual(date.strftime(format_string), expected_output)
+
+    def test_strftime_full_enEra(self):
+        for date, format_string, expected_output in self.test_cases_strftime_E:
+            with self.subTest(date=date):
+                self.assertEqual(date.strftime(format_string), expected_output)
+
+    def test_strftime_abbr_enEra(self):
+        for date, format_string, expected_output in self.test_cases_strftime_e:
             with self.subTest(date=date):
                 self.assertEqual(date.strftime(format_string), expected_output)
 


### PR DESCRIPTION
This pull request addresses multiple issues to improve the usability and flexibility of the jpdatetime library. The changes include enhanced formatting options, support for English era names, and a configuration refactor to make the code more maintainable.

Key Changes:

Support Format Modifiers for Non-Zero-Padded Era Years (%-G, %#G, etc.):

Added support for format modifiers that allow users to control whether era years are zero-padded. This brings more versatility in formatting Japanese era years, making them consistent with other standard Python strftime functionalities.

Add Zero Padding for Era Year Format:

Implemented zero-padding for era year formatting to align with typical expectations for date output. This feature helps ensure consistent output across different contexts where date padding is required.

Add Format %E for Full English Era Names and %e for Abbreviated English Era Initials:

Introduced %E and %e format specifiers to provide era names in English. %E outputs the full English name (e.g., "Reiwa 5"), while %e provides an abbreviated version (e.g., "R5"). This addition makes the library more accessible to non-Japanese speakers and expands its versatility for international projects.

Externalize Era List:

Moved the era list configuration to an external data structure to simplify the maintenance and extension of era definitions. By externalizing the era definitions, future changes—such as the addition of new eras—can be managed more easily without deep code modifications.

Benefits:

Greater Flexibility in Date Formatting: Users can now fine-tune the presentation of era years, such as opting for non-zero-padded outputs where preferred.

Enhanced International Support: The addition of English era names broadens the usability of the library for developers working on international projects.

Improved Maintainability: Externalizing the era list makes future updates to era definitions straightforward, reducing the likelihood of errors and simplifying the maintenance process.

Testing:

Added unit tests for all new format specifiers (%-G, %E, %e, etc.) to ensure the expected behavior for both zero-padded and non-zero-padded formats.

Verified the functionality for both Japanese and English era names to ensure correctness and consistency across different formatting scenarios.

Please review these changes and let me know if further adjustments are needed or if there are additional features you'd like to see implemented.